### PR TITLE
fixed conda install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ On a MacOS with HomeBrew use::
 
 Or if you manage binary packages with *Conda* use::
 
-    $ conda install -c conda-forge eccodes
+    $ conda install -c conda-forge python-eccodes
 
 As an alternative you may install the official source distribution
 by following the instructions at


### PR DESCRIPTION
The current conda install command in the README
```
conda install -c conda-forge eccodes
```
does not work as expected (at least I expected to get the python bindings with it). The self check fails because no python package get installed.

One needs the python bindings
```
conda install -c conda-forge python-eccodes
```